### PR TITLE
Handle HTTP Errors correctly (Issue #4)

### DIFF
--- a/s3
+++ b/s3
@@ -150,10 +150,19 @@ class AWSCredentials(object):
         """urlopen(url) open the remote file and return a file object."""
         try:
             return urllib2.urlopen(self._request(url), None, 30)
+        except urllib2.HTTPError as e:
+            # HTTPError is a "file like object" similar to what
+            # urllib2.urlopen returns, so return it and let caller
+            # deal with the error code
+            return e
+        # For other errors, throw an exception directly
         except urllib2.URLError as e:
-            Exception("URL timeout")
+            if hasattr(e, 'reason'):
+                raise Exception("URL error reason: %s" % e.reason)
+            elif hasattr(e, 'code'):
+                raise Exception("Server error code: %s" % e.code)
         except urllib2.socket.timeout:
-            Exception("Socket timeout")
+            raise Exception("Socket timeout")
 
     def _request(self, url):
         request = urllib2.Request(url)
@@ -290,7 +299,7 @@ class S3_method(object):
         if response.code != 200:
             self.send_uri_failure({
                 'URI': self.uri,
-                'Message': str(response.code + '  ' + response.msg),
+                'Message': str(response.code) + '  ' + response.msg,
                 'FailReason': 'HttpError' + str(response.code)})
             while True:
                 data = response.read(4096)


### PR DESCRIPTION
When urllib2 returns an HTTP error, return the file like exception
object and let error processing proceed based on the existing code.
This helps apt-get actually print a useful error message instead
of dumping the Python method invocation exception.