### PR TITLE
Quote filename characters so S3 requests actually succeed.

### DIFF
--- a/s3
+++ b/s3
@@ -277,11 +277,23 @@ class S3_method(object):
             else:
                 return 100
 
+    # We need to be able to quote specific characters to support S3
+    # lookups, something urllib and friends don't do easily
+    def quote(self, s, unsafe):
+        res = list(s)
+        for i in range(len(res)):
+            c = res[i]
+            if c in unsafe:
+                res[i] = '%%%02X' % ord(c)
+        return ''.join(res)
+
     def fetch(self, msg):
         self.uri = msg['URI']
         self.uri_parsed = urlparse.urlparse(self.uri)
+        # quote path for +, ~, and spaces
+        # see bugs.launchpad.net #1003633 and #1086997
         self.uri_updated = 'https://' + self.uri_parsed.netloc +\
-            self.uri_parsed.path
+            self.quote(self.uri_parsed.path, '+~ ')
         self.filename = msg['Filename']
 
         response = self.iam.urlopen(self.uri_updated)


### PR DESCRIPTION
Filenames that include a '+', '~', or space character need those
characters encoded using %NN codes for S3 to find them.
See LP [#1003633](https://bugs.launchpad.net/ubuntu/+source/apt/+bug/1003633), [#1086997](https://bugs.launchpad.net/ubuntu/+source/apt/+bug/1086997).

There are multiple examples of packages with a `+` in the filename
in the official repository. In my specific case the problem arose with
the use of [java-package](https://packages.debian.org/wheezy/java-package) which produced a file named like this: 
`oracle-j2sdk1.6_1.6.0+update45_amd64.deb`.

See also `methods/http.cc` in the apt source for any additional
background.