### PR TITLE
fixing issues with python 2.7.10

### DIFF
--- a/s3
+++ b/s3
@@ -172,7 +172,7 @@ class AWSCredentials(object):
             'Authorization', "AWS {0}:{1}".format(
                 self.access_key,
                 signature
-            )
+            ).replace("\n","")
         )
         return request
 


### PR DESCRIPTION
Using apt-transport-s3 does not work with python 2.7.10 (maybe even 2.7.9) due to updates in urllib. Urllib checks http headers more rigorously and this causes an issue with a newline in the header.
This patch removes the unwanted newline before the header goes to urllib.
