### PR TITLE
Properly default token

### DIFF
--- a/s3
+++ b/s3
@@ -168,7 +168,7 @@ class AWSCredentials(object):
         if self.secret_key is None or self.secret_key == '':
             raise Exception("SecretAccessKey required")
 
-        self.token = data['Token']
+        self.token = data.get('Token')
 
     def v4Sign(self, key, msg):
         return hmac.new(key, msg.encode('utf-8'), hashlib.sha256).digest()


### PR DESCRIPTION
Otherwise we see:

Traceback (most recent call last):
  File "/usr/lib/apt/methods/s3", line 551, in <module>
    method = S3_method(config)
  File "/usr/lib/apt/methods/s3", line 364, in __init__
    self.iam.get_credentials()
  File "/usr/lib/apt/methods/s3", line 171, in get_credentials
    self.token = data['Token']
  File "/usr/lib/python2.7/dist-packages/configobj.py", line 554, in __getitem__
    val = dict.__getitem__(self, key)
KeyError: 'Token'