### PR TITLE
Fix ISSUE #32

### DIFF
--- a/s3
+++ b/s3
@@ -30,11 +30,6 @@ import socket
 import ssl
 from configobj import ConfigObj
 
-RETRIES = 5
-
-
-def wait_time(c):
-    return pow(2, c) - 1
 
 RETRIES = 5
 
@@ -76,7 +71,7 @@ class AWSCredentials(object):
             except urllib2.URLError as e:
                 if hasattr(e, 'reason'):
                     raise Exception("URL error reason: %s, probable cause is that\
-     you don't have IAM role on this machine" % e.reason)
+     you don't have IAM role on this machine"                                              % e.reason)
                 elif hasattr(e, 'code'):
                     raise Exception("Server error code: %s" % e.code)
             finally:
@@ -208,8 +203,10 @@ class AWSCredentials(object):
 
     def _request(self, uri):
         uri_parsed = urlparse.urlparse(uri)
-        if '.' in uri_parsed.netloc:
-            raise Exception("uri should not include fully qualified domain name for bucket")
+        if uri_parsed.netloc.endswith(".amazonaws.com"):
+            raise Exception(
+                "uri '{}' should not include fully qualified domain name (.amazonaws.com) for bucket.\n".format(uri) +
+                "The bucket repo should be specified as 'deb s3://aptbucketname/repo/ trusty main contrib non-free'")
 
         # quote path for +, ~, and spaces
         # see bugs.launchpad.net #1003633 and #1086997

--- a/s3
+++ b/s3
@@ -71,7 +71,7 @@ class AWSCredentials(object):
             except urllib2.URLError as e:
                 if hasattr(e, 'reason'):
                     raise Exception("URL error reason: %s, probable cause is that\
-     you don't have IAM role on this machine"                                              % e.reason)
+     you don't have IAM role on this machine" % e.reason)
                 elif hasattr(e, 'code'):
                     raise Exception("Server error code: %s" % e.code)
             finally:


### PR DESCRIPTION
Fix ISSUE #32 .

Using the configured bucket repo
`deb s3://aptbucketname/repo trusty main contrib non-free`

we build a "S3 Path Style" url
`https://s3.{region}.amazonaws.com/aptbucketname/repo`

The `aptbucketname` **should not** be configured as a fully qualified name, for example
`deb s3://aptbucketname.s3.amazonaws.com/repo trusty main contrib non-free`

### NOTE from AWS [documentation](https://docs.aws.amazon.com/AmazonS3/latest/dev/BucketRestrictions.html)
> When using virtual hosted–style buckets with SSL, the SSL wildcard certificate only matches buckets that do not contain periods. To work around this, use HTTP or write your own certificate verification logic. We recommend that you do not use periods (".") in bucket names.

This only applies to "virtual hosted–style buckets" but we use "path style buckets".